### PR TITLE
Upgrade actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Checkout p537
         uses: actions/checkout@v4
       - name: Setup Python 3.6
-        uses: gabrielfalcao/pyenv-action@v18
+        # Upgrade node16 -> node20: Out for review here:
+        #   https://github.com/gabrielfalcao/pyenv-action/pull/444
+        uses: pex-tool/pyenv-action@baec18679698d2f80064cc04eb9ad0c8dc5ca8f8
         env:
           ENSUREPIP: no
         with:


### PR DESCRIPTION
This eliminates node16 warnings / prepares for the spring when node16 
goes away.